### PR TITLE
correct return code 

### DIFF
--- a/src/helper.jl
+++ b/src/helper.jl
@@ -5,6 +5,25 @@ import MathProgBase
 
 export get_nlp_evaluator, convert_to_lower, array_copy, write_mat_to_file, convert_to_c_idx, write_x, @declare_second_stage, message
 export strip_x, build_x
+export PIPSRetCodeToSolverInterfaceCode
+
+const PIPSRetCode = Dict{Int, Symbol}(
+    0=>:SUCCESSFUL_TERMINATION,
+    1=>:NOT_FINISHED,
+    2=>:MAX_ITS_EXCEEDED,
+    3=>:INFEASIBLE,
+    4=>:NEED_FEASIBILITY_RESTORATION,
+    5=>:UNKNOWN
+    )
+
+const PIPSRetCodeToSolverInterfaceCode = Dict{Int, Int}(
+    0=>0,
+    1=>8,
+    2=>-1,
+    3=>2,
+    4=>7,
+    5=>8
+    )
 
 function strip_x(m,id,x,start_idx)
     mm = getModel(m,id)

--- a/src/pips_parallel.jl
+++ b/src/pips_parallel.jl
@@ -607,7 +607,7 @@ function structJuMPSolve(model; with_prof=false, suppress_warmings=false,kwargs.
         run(`mv $n1 $n2`)
     end
     # MPI.Finalize()
-    return status
+    return PIPSRetCodeToSolverInterfaceCode[status]
 end
 
 # function load_x(subdir,iter)

--- a/src/pips_serial.jl
+++ b/src/pips_serial.jl
@@ -368,7 +368,7 @@ function structJuMPSolve(model; suppress_warmings=false,kwargs...)
     status = solveProblem(prob)
     nm.write_solution(prob.x)
     
-    return status
+    return PIPSRetCodeToSolverInterfaceCode[status]
 end
 
 KnownSolvers["PipsNlpSerial"] = PipsNlpInterfaceSerial.structJuMPSolve


### PR DESCRIPTION
This PR introduces a return code mapping that is required by the solvehook function in JuMP. 
It takes the solver's return code from PIPS-NLP or Ipopt and converts the return code to a symbol using Ipopt standards. 